### PR TITLE
updates for apt

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Sponsored by [BidMath](http://bidmath.com/)
     - { role: pedrocarmona.github-git-lfs }
 ```
 
-
 ## License
 
 MIT / BSD

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-git_lfs_version: 1.1.0
+git_lfs_version: 1.4.4

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,14 +1,13 @@
 ---
 dependencies:
-  - { role: geerlingguy.git }
-
+  - src: geerlingguy.git
 
 galaxy_info:
   author: pedrocarmona
   company: BidMath
   description: Git Large File Storage
   license: "license (BSD, MIT)"
-  min_ansible_version: 1.4
+  min_ansible_version: 2.1
   platforms:
   - name: EL
     versions:

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -6,19 +6,22 @@
   apt:
     name: "{{ item }}"
     state: latest
-    update_cache: yes
   with_items:
     - debian-archive-keyring
     - apt-transport-https
 
 - name: Ensure repository configuration (Debian)
-  template: >
-    src=debian.github_git-lfs.list.j2
-    dest=/etc/apt/sources.list.d/github_git-lfs.list
-    owner=root group=root mode=0644
+  apt_repository: >
+    repo={{ item }}
+    state=present
+    filename=github_git-lfs
+    update_cache=yes
+    mode=0644
+  with_items:
+    - "deb https://packagecloud.io/github/git-lfs/{{ansible_distribution|lower}}/ {{ansible_distribution_release}} main"
+    - "deb-src https://packagecloud.io/github/git-lfs/{{ansible_distribution|lower}}/ {{ansible_distribution_release}} main"
 
 - name: Ensure github git-lfs is installed (Debian)
   apt:
     name=git-lfs={{ git_lfs_version }}
     state=present
-    update_cache=yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,8 @@
 ---
 - include: redhat.yml
   when: ansible_os_family == 'RedHat'
+  tags: ['git-lfs']
 
 - include: debian.yml
   when: ansible_os_family == 'Debian'
+  tags: ['git-lfs']

--- a/templates/debian.github_git-lfs.list.j2
+++ b/templates/debian.github_git-lfs.list.j2
@@ -1,2 +1,0 @@
-deb https://packagecloud.io/github/git-lfs/{{ansible_distribution|lower}}/ {{ansible_distribution_release}} main
-deb-src https://packagecloud.io/github/git-lfs/{{ansible_distribution|lower}}/ {{ansible_distribution_release}} main

--- a/tests/test-install-package.yml
+++ b/tests/test-install-package.yml
@@ -1,6 +1,6 @@
 ---
 - hosts: localhost
-  sudo: true
+  become: true
   vars:
     user: deploy
     group: deploy


### PR DESCRIPTION
minor changes to:

- use `apt_repository` module rather than template
- **don't** update apt cache all the time
- tag tasks as `git-lfs` and
- require ansible 2.1+ (for `apt_repository.filename` param)
